### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Public Key Record (from hardware wallet) in regular encoding:
 
 ### Buidl Verification
 
-This could be generated in build as follows:
+This could be generated in buidl as follows:
 ```
 $ python3
 >>> from buidl.hd import HDPrivateKey
@@ -107,7 +107,7 @@ Type help or ? to list commands.
 (₿) advanced_mode
 ADVANCED mode set, don't mess up!
 (₿) blind_xpub
-Enter an xpub key record to blind in the format [deadbeef/path]xpub (any path will do): [2553c4b8[2553c4b8/48h/1h/0h/2h]Vpub5maJud3od8qgmvi3XPpnweRsBm4ir8QdVTesjtmt8Q3nV48HncG1sddZCMhr6W6GRoAs3svAXvGZ8GF98rQkHH5UMtCHJimTNNjNSWZUapk
+Enter an xpub key record to blind in the format [deadbeef/path]xpub (any path will do): [2553c4b8/48h/1h/0h/2h]Vpub5maJud3od8qgmvi3XPpnweRsBm4ir8QdVTesjtmt8Q3nV48HncG1sddZCMhr6W6GRoAs3svAXvGZ8GF98rQkHH5UMtCHJimTNNjNSWZUapk
 Use standard entropy parameters for blinding? [Y/n]: 
 Generating BIP32 path with 124 bits of good entropy...
 Here is a blinded xpub key record to upload to your Coordinator.


### PR DESCRIPTION
General comments and questions:
- I wasn't sure if that was a typo or not in the Blind 1 Seed Phrase section since it was also in the screenshot (so presumably coming from the software), but it looked weird so I thought I'd edit just in case. Feel free to reject.

- I think it would be good to include potential downsides/foot guns somewhere, similar to the pros/cons list in the original [gist](https://gist.github.com/mflaxman/d72d25ad00941cea8241b6667cf008a8). Maybe even enumerate pros as well as cons here.

- Feel free to ignore this feedback or correct some misunderstanding I might be having since this could be totally subjective and narrow or me being wrong about something, but I felt a little confused by the name "blinded xpub". The initial image that it evokes in my head is that you're doing some kind of masking with the "passphrase" (i.e. the randomly generated path). What I imagined would happen with this mask is that you could apply it to a given account map to generate the _actual_ map. That doesn't seem to be what's going on though and instead it's more that the privacy protection is that the address is obscured by making it difficult to grind through the possible paths that would be associated with a given xpub. Once the account map is exposed though, all privacy benefits are lost. The only real difference from my using someone's xpub to generate a multisig and the blinded process is that the owner of the xpub would be less likely or able to guess what pubkeys that appear in the blockchain belong to it. Does this sound right? I'm not making a value judgement one way or the other, just trying to clarify in my head and also throw it out there in case there's a chance it could be confusing for others.
 
- One thing that I liked in the gist which didn't seem to be included here is the use of a passphrase to generate the path as opposed to just entropy (I could've missed it though. There are a couple mentions of a passphrase, but that seemed to be for encrypting the seed). I think that is a really nice feature of this proposal and imo should definitely be mentioned if you ever promote this to a BIP proposal. Benefits include: 
1) Many keystores already support passphrase entry even with limited input mechanisms. 
2) It's easy to grock for less technical users (e.g. "This passphrase generates the path needed for the account amp") 
3) It feels easier to backup and in some ways more secure since it can be stored in a way that's more ambiguous as to what it is. 
4) standardization will likely be needed for passphrase support around things like word list, capitalization, length, etc. 
5) As you mention, complexity is the enemy of security and it's pretty unlikely with a decent passphrase that this could be guessed. Making it easy to remember and convey feels more important and a bigger win

- Just spitballing here: an interesting way to add additional support in something like Caravan would be to have an extra field for a passphrase entry with an xpub that then generates the "blinded" xpub. So after you upload your xpub from a device or paste it in plain text, you'd have something like a checkbox that says: "blinded?", check it and then an input shows up that you enter the passphrase which generates the blinded path and resulting xpub which are used in the config/account map. To the point #5 above, we could even opt to not save that in the wallet config that is exported and so in order to load the watch only wallet, you have to know the blinding passphrase(s) and which key(s) they apply to. 